### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 on:
   push: { }
   pull_request: { }
+permissions:
+  contents: read
 jobs:
   build-and-test:
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish
 on:
   release:
     types: [ published ]
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both the build and publish workflows lack explicit permissions declarations, which triggers code scanning alerts #2 and #3 (actions/missing-workflow-permissions). This adds minimal `permissions: contents: read` to each workflow, following the principle of least privilege. Both workflows only need read access to check out the repository; all external service authentication (Codecov, PyPI) is handled via dedicated secrets/tokens.