### PR TITLE
Fix README typo, dependabot config, and publish workflow versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install poetry
@@ -19,7 +19,7 @@ jobs:
         run: |
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Define a cache for the virtual environment based on the dependencies lock file
         with:
           path: ./.venv

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Create and get the bot token (under "OAuth & Permissions") and app token (under 
 pip install slack-time-localization-bot
 ```
 
-> ℹ️ Currently only Linx x86_64 is supported
+> ℹ️ Currently only Linux x86_64 is supported
 
 Finally you can run it with
 


### PR DESCRIPTION
Fix typo in README.md ("Linx" -> "Linux"), add the github-actions ecosystem to dependabot.yml so GitHub Actions dependencies get automated update PRs, and bump actions/setup-python from v4 to v5 and actions/cache from v3 to v4 in publish.yml to match what build.yml already uses.