### PR TITLE
Remove .idea directory from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="USE_PROJECT_PROFILE" value="false" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Black">
-    <option name="sdkName" value="Poetry (slack-time-localization-bot)" />
-  </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (slack-time-localization-bot)" project-jdk-type="Python SDK" />
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/slack-time-localization-bot.iml" filepath="$PROJECT_DIR$/.idea/slack-time-localization-bot.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/slack-time-localization-bot.iml
+++ b/.idea/slack-time-localization-bot.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Poetry (slack-time-localization-bot)" jdkType="Python SDK" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
The .idea directory contains JetBrains IDE configuration files that are user-specific and should not be tracked in version control. The .gitignore already had a commented-out entry for it; this PR removes the tracked files and activates the gitignore rule.